### PR TITLE
Change default rake task to 'rspec -fd spec'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task :default => [:spec]
 
 desc 'Run specs'
 task :spec do
-  sh 'rspec spec'
+  sh 'rspec -fd spec'
 end
 
 desc 'Sets up the application. (parameters: NAME, GITKEEP=true/false)'


### PR DESCRIPTION
- `Rakefile`:
  - Change default rake task `:spec` from
    ```bash
     $ rspec spec
     ``` 
     to 
     ```bash
     $ rspec -fd spec
     ```
    for more detailed and summarized specs.