### PR TITLE
Add manifest.rb + clean up app.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,10 @@ gem 'sass'
 gem 'uglifier'
 
 # Hanami HTML/asset helpers
-gem 'hanami-helpers', require: 'hanami/helpers'
-gem 'hanami-assets', require: ['hanami/assets','hanami/assets/helpers']
+group :hanami do
+    gem 'hanami-helpers', require: 'hanami/helpers'
+    gem 'hanami-assets', require: ['hanami/assets','hanami/assets/helpers']
+end
 
 # ActiveRecord for models and records
 gem 'activerecord', require: ['active_support','active_support/core_ext']
@@ -29,13 +31,13 @@ gem 'sinatra-activerecord', require: ['sinatra/activerecord','sinatra/activereco
 # Logging
 gem 'lumberjack'
 
-group :development, :test do
-    gem 'sqlite3'
+# Database adapters
+gem 'sqlite3', group: [:development, :test]
+gem 'pg', group: :production
+
+# Test environment
+group :test do
     gem 'rack-test', require: 'rack/test'
     gem 'rspec'
     gem 'shoulda-matchers'
-end
-
-group :production do
-    gem 'pg'
 end

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ The template's directory is currently structured as follows:
 ├── app.rb                         #=> Core application data
 ├── config                         #
 │   ├── database.yml               #=> Database configuration
-│   └── initializers.rb            #=> Initializers file
+│   ├── initializers.rb            #=> Initializers file
+│   ├── manifest.rb                #=> Manifest file accessor configuration
+│   └── static.rb                  #=> Static data accessor configuration
 ├── config.ru                      #=> config.ru for rack instructions
 ├── log                            #=> Log files
 └── spec                           #=> RSpec test files

--- a/app.rb
+++ b/app.rb
@@ -1,15 +1,14 @@
+$dir = File.dirname(__FILE__)
+
 require 'bundler'
 Bundler.require :default
 
-$DIR = File.dirname(__FILE__)
-Dir["#$DIR/config/*.rb"].each{|file|require file}
-Dir["#$DIR/app/helpers/*.rb"].each{|file|require file}
-Dir["#$DIR/app/models/*.rb"].each{|file|require file}
-Dir["#$DIR/app/controllers/*.rb"].each{|file|require file}
+Dir["#$dir/config/*.rb"].each{|file|require file}
+Dir["#$dir/app/{helpers,models,controllers}/*.rb"].each{|file|require file}
 
 class ApplicationController < Sinatra::Base
     # Set views, templates and partials
-    set :views, ->{"#$DIR/app/views"}
+    set :views, "#$dir/app/views"
 
     # Set default ERB template
     set :erb, layout: :'templates/layout'
@@ -17,7 +16,7 @@ class ApplicationController < Sinatra::Base
     # Set logger variables
     %i[test production development].each do |env|
         configure env do
-            set :logger, ->{Lumberjack::Logger.new("log/#{env}.log")}
+            set :logger, Lumberjack::Logger.new("#$dir/log/#{env}.log")
         end
     end
 
@@ -32,19 +31,5 @@ class ApplicationController < Sinatra::Base
     get '/assets/*' do
         env["PATH_INFO"].sub!('/assets','')
         settings.environment.call(env)
-    end
-
-    # Application manifest file accessor method
-    def application(*args)
-        html = String.new
-        css_syms = %i[css stylesheet]
-        js_syms = %i[js javascript]
-        args.map(&:to_sym).each do |arg|
-            html << stylesheet('application') if css_syms.include? arg
-            html << javascript('application') if js_syms.include? arg
-        end
-        html
-    rescue
-        raise ArgumentError.new("Expected arguments to be any of: #{css_syms+js_syms}")
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+Bundler.require :hanami
 class ApplicationController < Sinatra::Base
     helpers ApplicationHelper, Hanami::Helpers, Hanami::Assets::Helpers
 

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 require './app'
-Dir["#{File.dirname(__FILE__)}/app/controllers/*.rb"]
+Dir["#$dir/app/controllers/*.rb"]
     .map{|f|File.basename(f,'.*').camelize}
     .reject(&'ApplicationController'.method(:==))
     .each{|c|use c.constantize}

--- a/config/manifest.rb
+++ b/config/manifest.rb
@@ -1,0 +1,16 @@
+require 'bundler'
+Bundler.require :hanami
+
+# Application manifest file accessor method
+def application(*args)
+    html = String.new
+    css = %i[css stylesheet]
+    js = %i[js javascript]
+    args.map(&:to_sym).each do |arg|
+        html << stylesheet('application') if css.include? arg
+        html << javascript('application') if js.include? arg
+    end
+    html
+rescue
+    raise ArgumentError.new("Expected arguments to be any of: #{css+js}")
+end


### PR DESCRIPTION
- `Gemfile`:
  - Add `:hanami` group for assets
  - Move test environment out of `:development` group
- `app.rb`:
  - Change `$DIR` global variable to `$dir`
  - Combine require directives for `Dir.glob` in `app/helpers`, `app/controllers`, `app/models` into one directive
  - Remove unnecessary lambda definitions for Sinatra settings (`settings.views`, `settings.logger`)
  - Move application manifest file accessor method to `config/manifest.rb`
- `application_controller.rb`:
  - Add `:hanami` Gemfile group require directive
- `config.ru`:
  - Use `$dir` global variable instead of using `File.dirname(__FILE__)` again
- `config/manifest.rb`:
  - Create file (moved application manifest file accessor method from `app.rb` to this file)
- `README.md`:
  - Add `manifest.rb` and `static.rb` to directory structure tree