### PR TITLE
Remove require directive in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,4 @@
-require 'sinatra/activerecord'
-require 'sinatra/activerecord/rake'
-require 'active_support/core_ext'
-require './app.rb'
+require './app'
 
 task :default => [:spec]
 


### PR DESCRIPTION
- `Rakefile`:
  - Remove file extension from `require './app.rb'`
  - Remove `activerecord` and `active_support` require directives