### PR TITLE
Add blog redirect pattern match after other routes

### DIFF
--- a/rake/blog/gen/controller.rake
+++ b/rake/blog/gen/controller.rake
@@ -73,6 +73,10 @@ namespace :blog do
                             end
                             get "/#{route}/search/:query", &query
                             post "/#{route}/search/:query", &query
+
+                            get %r{/#{route}/.*} do
+                                redirect '/#{route}'
+                            end
                         end
                     EOF
                 end


### PR DESCRIPTION
- ` rake/blog/gen/controller.rake`:
  - Add blog redirect pattern match route handler for `%r{/#{route}/.*}` after other routes