### PR TITLE
Add docs + ruby version badge to README + change ruby version specifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.0'
+ruby '~> 2.5.0'
 
 gem 'sinatra', require: 'sinatra/base'
 gem 'bundler'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+[![Ruby Version](https://img.shields.io/badge/ruby-~%3E_2.5.0-red.svg)]()
 [![Release](https://img.shields.io/github/release/simplatra/simplatra.svg)](https://github.com/simplatra/simplatra/releases)
 [![License](https://img.shields.io/github/license/simplatra/simplatra.svg)](https://github.com/simplatra/simplatra/blob/master/LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-gitbook-blue.svg)](https://simplatra.gitbook.io/simplatra)
 
 # Simplatra
 


### PR DESCRIPTION
- `Gemfile`:
  - Change ruby version specifier directive from exact `2.5.0` to pessimistic version `~> 2.5.0`
- `README.md`:
  - Add ruby version badge
  - Add GitBook documentation badge