### PR TITLE
Change ruby version to 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '~> 2.5.0'
+ruby '2.5.0'
 
 gem 'sinatra', require: 'sinatra/base'
 gem 'bundler'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Ruby Version](https://img.shields.io/badge/ruby-~%3E_2.5.0-red.svg)](https://github.com/simplatra/simplatra/blob/master/Gemfile#L2)
+[![Ruby Version](https://img.shields.io/badge/ruby-2.5.0-red.svg)](https://github.com/simplatra/simplatra/blob/master/Gemfile#L2)
 [![Release](https://img.shields.io/github/release/simplatra/simplatra.svg)](https://github.com/simplatra/simplatra/releases)
 [![License](https://img.shields.io/github/license/simplatra/simplatra.svg)](https://github.com/simplatra/simplatra/blob/master/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-gitbook-blue.svg)](https://simplatra.gitbook.io/simplatra)


### PR DESCRIPTION
- `Gemfile`:
  - Revert to using `ruby '2.5.0'` directive rather than pessimistic versioning, since that caused a warning with RVM when `cd`ing into the directory.
- `README.md`:
  - Change `ruby` badge to display `2.5.0`