### PR TITLE
Fix spec generation and constant resolution + include test env in production group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'activerecord', require: ['active_support','active_support/core_ext']
 gem 'sinatra-activerecord', require: ['sinatra/activerecord','sinatra/activerecord/rake']
 
 # Test environment
-group :test do
+group :test, :production do
     gem 'rack-test', require: 'rack/test'
     gem 'rspec'
     gem 'shoulda-matchers'

--- a/config/controller.rb
+++ b/config/controller.rb
@@ -1,8 +1,9 @@
+class ApplicationController < Sinatra::Base; end
 module Simplatra
     def self.Controller(route:)
         name = File.basename(caller[0][/[^:]+/],'.*').camelize
-        Object.const_set(name,Class.new(ApplicationController))
+        Object.const_set(name,Class.new(::ApplicationController))
         name.constantize.instance_eval(%{def router() "#{route}" end})
-        ApplicationController
+        ::ApplicationController
     end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,4 +12,5 @@ test:
   database: db/test.sqlite3
 
 production:
+  adapter: postgresql
   url: <%= ENV['DATABASE_URL'] %>

--- a/thor/generators/blog.rb
+++ b/thor/generators/blog.rb
@@ -59,7 +59,7 @@ module Simplatra
                 route = route[0] == ?/ ? route : "/#{route}"
                 config = {route: route}
                 template("#{TEMPLATES}/blog/controller.tt", "#{Simplatra::ROOT}/app/controllers/blog_controller.rb", config)
-                template("#{TEMPLATES}/blog/spec.tt", "#{Simplatra::ROOT}/spec/controllers/blog_controller_spec.rb", config)
+                template("#{TEMPLATES}/blog/spec.tt", "#{Simplatra::ROOT}/spec/controllers/blog_controller_spec.rb")
             end
 
             def list

--- a/thor/generators/templates/blog/spec.tt
+++ b/thor/generators/templates/blog/spec.tt
@@ -9,6 +9,7 @@ describe BlogController do
 
     describe 'blog page' do
         # Implement this test!
+        get '/'
         it "should display all posts" do
             expect(true).to eq(false)
         end
@@ -16,21 +17,22 @@ describe BlogController do
 
     POSTS.each do |post|
         # Implement these tests!
+        subpath = post[:time].split(' ').first.gsub(?-,?/)
         describe "Post: #{post[:title]}" do
             it "should have a timestamp" do
-                get "<%= config[:route] %>/#{post[:urltitle]}"
+                get "/#{subpath}/#{post[:urltitle]}"
                 expect(true).to eq(false)
             end
             it "should have a title" do
-                get "<%= config[:route] %>/#{post[:urltitle]}"
+                get "/#{subpath}/#{post[:urltitle]}"
                 expect(true).to eq(false)
             end
             it "should have a description" do
-                get "<%= config[:route] %>/#{post[:urltitle]}"
+                get "/#{subpath}/#{post[:urltitle]}"
                 expect(true).to eq(false)
             end
             it "should have tags" do
-                get "<%= config[:route] %>/#{post[:urltitle]}"
+                get "/#{subpath}/#{post[:urltitle]}"
                 post[:tags].each do |tag|
                     expect(true).to eq(false)
                 end

--- a/thor/generators/templates/mvc/controller/spec.tt
+++ b/thor/generators/templates/mvc/controller/spec.tt
@@ -3,6 +3,7 @@ describe <%= config[:class_name] %> do
     def app() <%= config[:class_name] %> end
 
     it "should expect true to be true" do
+        get '/'
         expect(true).to be true
     end
 


### PR DESCRIPTION
- `Gemfile`
  - Include test environment in `production` group
- `config/controller.rb`
  - Fix constant resolution to global `ApplicationController` rather than resolving `Simplatra::ApplicationController`
  - Include reopening of `ApplicationController` class for context
- `config/database.yml`
  - Specify `postgresql` adapter for production database
- ` thor/generators/blog.rb`
  - Remove unnecessary passing of `config` to spec template
- `thor/generators/templates/blog/spec.tt`
  - Remove `config[:route]` and add subpath (due to relative routing change in v3.0.0)
- `thor/generators/templates/mvc/controller/spec.tt`
  - Add route request for spec