### PR TITLE
Remove datetime from 'blog article list'

### DIFF
--- a/app/views/blog/markdown/2018/07/22/test.md
+++ b/app/views/blog/markdown/2018/07/22/test.md
@@ -1,0 +1,9 @@
+---
+title: "TODO"
+desc: "TODO"
+tags: ["TODO"]
+# Only change the below fields with `simplatra blog article edit` commands!
+urltitle: "test"
+time: "2018-07-22 17:18:15"
+assetpath: "/assets/blog/2018/07/22/test/"
+---

--- a/app/views/blog/markdown/2018/07/22/test.md
+++ b/app/views/blog/markdown/2018/07/22/test.md
@@ -1,9 +1,0 @@
----
-title: "TODO"
-desc: "TODO"
-tags: ["TODO"]
-# Only change the below fields with `simplatra blog article edit` commands!
-urltitle: "test"
-time: "2018-07-22 17:18:15"
-assetpath: "/assets/blog/2018/07/22/test/"
----

--- a/lib/simplatra/generators/blog.rb
+++ b/lib/simplatra/generators/blog.rb
@@ -78,7 +78,7 @@ module Simplatra
         longest = 0
         metadata.each do |article|
           article.each do |k,v|
-            next if k == :desc
+            next if %i[desc datetime].include? k
             str = "#{k}: #{v}"
             longest = str.length if longest < str.length
           end
@@ -88,6 +88,7 @@ module Simplatra
           s << (chars[:corner]+chars[:horizontal]*(longest+2)+chars[:corner]+"\n")
           metadata.each do |article|
             article.each do |k,v|
+              next if k == :datetime
               str = "#{k}: #{v}"
               if k == :desc
                 value = v.to_s

--- a/lib/simplatra/version.rb
+++ b/lib/simplatra/version.rb
@@ -1,3 +1,3 @@
 module Simplatra
-  VERSION = "0.10.0.beta.3"
+  VERSION = "0.10.0.beta.4"
 end

--- a/lib/simplatra/version.rb
+++ b/lib/simplatra/version.rb
@@ -1,3 +1,3 @@
 module Simplatra
-  VERSION = "0.10.0.beta.4"
+  VERSION = "0.10.0.beta.5"
 end


### PR DESCRIPTION
# Changelog (commits)
- [Remove `:datetime` from '`blog article list`' display](https://github.com/simplatra/simplatra/commit/d3ac344626ac7145554970afe88cb82c394dab9d)
- [Bump VERSION](https://github.com/simplatra/simplatra/commit/aeb89b38854a67c74fe06a3a47eef2b891f13958) - (0.10.0.beta.4)
- [Delete `app` directory](https://github.com/simplatra/simplatra/commit/65b4523caa3a525ffd8428ed5abeb2c88fb7ba2b)
- [Bump VERSION](https://github.com/simplatra/simplatra/commit/fdf8c0dc1b264a0141c0b53898a6c3966422dd29) - (0.10.0.beta.5)